### PR TITLE
Switching out my entry for a broader repo

### DIFF
--- a/repositories.json
+++ b/repositories.json
@@ -429,8 +429,8 @@
 			"location": "https://raw.githubusercontent.com/rosenbergj/hubitat-shabbat-and-chag/main/repository.json"
 		},
 		{
-			"name": "Vyrolan iAqualink-Hubitat",
-			"location": "https://raw.githubusercontent.com/Vyrolan/iAqualink-Hubitat/main/repository.json"
+			"name": "Vyrolan",
+			"location": "https://raw.githubusercontent.com/Vyrolan/VyrolanHomeAutomation/main/Hubitat/repository.json"
 		},
 		{
 			"name": "dan.t",


### PR DESCRIPTION
Changing my entry that was specific to my iAqualink driver to a more generic one so I can keep all my various HA stuff together.