### PR TITLE
Add KTriponis repository

### DIFF
--- a/repositories.json
+++ b/repositories.json
@@ -499,6 +499,10 @@
 		{
 			"name": "Jonathan Bradshaw",
 			"location": "https://raw.githubusercontent.com/bradsjm/hubitat-drivers/main/repository.json"
+		},
+		{
+			"name": "KTriponis",
+			"location": "https://raw.githubusercontent.com/ktriponis/hubitat-packages/main/repository.json"
 		}
 	],
 	"hpm": {


### PR DESCRIPTION
Added a new repository that currently contains Elgato Key Light drivers developed I while ago to help users install and get new updates.