### PR TITLE
- add repository for current and future Hubitat drivers

### DIFF
--- a/repositories.json
+++ b/repositories.json
@@ -511,6 +511,10 @@
 		{
 			"name": "Bloodtick Jones",
 			"location": "https://raw.githubusercontent.com/bloodtick/Hubitat/main/hubitat-packages/repository.json"
+		},
+		{
+			"name": "Joe Page",
+			"location": "https://raw.githubusercontent.com/jpage4500/hubitat-drivers/master/repository.json"
 		}
 	],
 	"hpm": {


### PR DESCRIPTION
I'm starting with updating the existing Life360 with State app which is no longer being maintained or in HPM (https://community.hubitat.com/t/release-life360-with-states-track-all-attributes-with-app-and-driver-also-supports-rm4-and-dashboards/18274)

I've refactored quite a bit of the code to simplify and expose more values.. make the driver less noisy (fewer events). I'm going to create a new forum thread with details next but wanted to get this into HPM around the same time

thanks!
joe