### PR TITLE
Update repositories.json for SW2500ZB

### DIFF
--- a/repositories.json
+++ b/repositories.json
@@ -1,6 +1,10 @@
 {
 	"repositories": [
 		{
+			"name": "SORS",
+			"location": "https://raw.githubusercontent.com/sorsme/sinope-switch/main/repository.json"
+		},
+		{
 			"name": "dman2306",
 			"location": "https://raw.githubusercontent.com/dcmeglio/hubitat-packages/master/repository.json"
 		},


### PR DESCRIPTION
New driver for Sinope SW2500ZB, which supports double and long taps