### PR TITLE
Add new repository: obeisser/hubitat-drivers

### DIFF
--- a/repositories.json
+++ b/repositories.json
@@ -720,6 +720,10 @@
 			"name": "Mathew Beall",
       		"location": "https://raw.githubusercontent.com/mathewbeall/hubitat-resideo_T10-integration/main/repository.json"
   		}
+		{
+    		"name": "obeisser",
+    		"location": "https://raw.githubusercontent.com/obeisser/hubitat-drivers/main/repository.json"
+		}
 	],
 	"hpm": {
 		"location": "https://raw.githubusercontent.com/HubitatCommunity/hubitatpackagemanager/main/packageManifest.json"


### PR DESCRIPTION
Added new repository first driver: WLED Universal Driver

{
    "name": "obeisser",
    "location": "https://raw.githubusercontent.com/obeisser/hubitat-drivers/main/repository.json"
}