### PR TITLE
Add uDevel repository (SOMA Smart Shades 3 driver)

### DIFF
--- a/repositories.json
+++ b/repositories.json
@@ -787,6 +787,10 @@
 		{
 			"name": "brossow",
 			"location": "https://raw.githubusercontent.com/brossow/hubitat-econet/main/repository.json"
+		},
+		{
+			"name": "uDevel",
+			"location": "https://raw.githubusercontent.com/uDevel/hubitat-soma-shades-3/main/repository.json"
 		}
 	],
 	"hpm": {


### PR DESCRIPTION
## Summary
Adds a new author repository `uDevel` for the **SOMA Smart Shades 3 (Zigbee) driver**.

- Repo: https://github.com/uDevel/hubitat-soma-shades-3
- Manifest: https://raw.githubusercontent.com/uDevel/hubitat-soma-shades-3/main/packageManifest.json
- Repository JSON: https://raw.githubusercontent.com/uDevel/hubitat-soma-shades-3/main/repository.json
- License: MIT