### PR TITLE
Update brossow repository location to hubitat-packages

### DIFF
--- a/repositories.json
+++ b/repositories.json
@@ -786,7 +786,7 @@
 		},
 		{
 			"name": "brossow",
-			"location": "https://raw.githubusercontent.com/brossow/hubitat-econet/main/repository.json"
+			"location": "https://raw.githubusercontent.com/brossow/hubitat-packages/main/repository.json"
 		},
 		{
 			"name": "uDevel",


### PR DESCRIPTION
Moves the repository index from the project-specific `hubitat-econet` repo to a dedicated `hubitat-packages` repo, so all future package additions and updates are decoupled from any individual driver project.

The new location: https://raw.githubusercontent.com/brossow/hubitat-packages/main/repository.json

Contents are identical — no packages added or removed.