### PR TITLE
Update brossow repository location

### DIFF
--- a/repositories.json
+++ b/repositories.json
@@ -1,799 +1,799 @@
 {
-	"repositories": [
-		{
-			"name": "dman2306",
-			"location": "https://raw.githubusercontent.com/dcmeglio/hubitat-packages/master/repository.json"
-		},
-		{
-			"name": "Victor Santana (Welasco)",
-			"location": "https://raw.githubusercontent.com/Welasco/hubitat/master/repository.json"
-		},
-		{
-			"name": "Ramdev Shallem",
-			"location": "https://raw.githubusercontent.com/gilshallem/Hubitat/main/HPM/repositories.json"
-		},
-		{
-			"name": "BPTWorld",
-			"location": "https://raw.githubusercontent.com/bptworld/Hubitat/master/repositories.json"
-		},
-		{
-			"name": "AaronW",
-			"location": "https://raw.githubusercontent.com/PrayerfulDrop/Hubitat/master/repository.json"
-		},
-		{
-			"name": "bcopeland",
-			"location": "https://raw.githubusercontent.com/djdizzyd/hubitat/master/packages/repositories.json"
-		},
-		{
-			"name": "heidrickla (Lewis.Heidrick)",
-			"location": "https://raw.githubusercontent.com/heidrickla/Hubitat/main/Docs/repository.json"
-		},
-		{
-			"name": "storageaanarchy (SANdood)",
-			"location": "https://raw.githubusercontent.com/SANdood/Hubitat-Stuff/master/repository.json"
-		},
-		{
-			"name": "RMoRobert (BertABCD1234)",
-			"location": "https://raw.githubusercontent.com/RMoRobert/Hubitat/master/repository.json"
-		},
-		{
-			"name": "Dave Gutheinz(DavGut)",
-			"location": "https://raw.githubusercontent.com/DaveGut/HubitatActive/master/repository.json"
-		},
-		{
-			"name": "Matthew (@scottma61)",
-			"location": "https://raw.githubusercontent.com/Scottma61/Hubitat/master/docs/Matthew_repository.json"
-		},
-		{
-			"name": "Miles Budnek (@mbudnek)",
-			"location": "https://raw.githubusercontent.com/mbudnek/hubitat-package-manager-repo/master/repository.json"
-		},
-		{
-			"name": "Inovelli",
-			"location": "https://raw.githubusercontent.com/InovelliUSA/Hubitat/master/repository.json"
-		},
-		{
-			"name": "Markus (@markus)",
-			"location": "https://raw.githubusercontent.com/markus-li/Hubitat/release/repository.json"
-		},
-		{
-			"name": "Joseph Kregloh",
-			"location": "https://raw.githubusercontent.com/funzie19/hubitat-solaredge/master/repositories.json"
-		},
-		{
-			"name": "Anthony S. (tonesto7)",
-			"location": "https://raw.githubusercontent.com/tonesto7/hubitat/master/repository.json"
-		},
-		{
-			"name": "MFornander",
-			"location": "https://raw.githubusercontent.com/MFornander/Hubitat/master/respository.json"
-		},
-		{
-			"name": "imnotbob",
-			"location": "https://raw.githubusercontent.com/imnotbob/webCoRE/hubitat-patches/HE/repository.json"
-		},
-		{
-			"name": "nh.schottfam",
-			"location": "https://raw.githubusercontent.com/imnotbob/Hubitat-Intesis/master/repository.json"
-		},
-		{
-			"name": "apwelsh",
-			"location": "https://raw.githubusercontent.com/apwelsh/hubitat/master/repository.json"
-		},
-		{
-			"name": "bsileo",
-			"location": "https://raw.githubusercontent.com/bsileo/hubitat_poolcontroller/master/repository.json"
-		},
-		{
-			"name": "Brian Wilson (@brianwilson)",
-			"location": "https://raw.githubusercontent.com/bdwilson/hubitat/master/repository.json"
-		},
-		{
-			"name": "napalmcsr",
-			"location": "https://raw.githubusercontent.com/napalmcsr/Hubitat_Napalmcsr/master/docs/HPM.json"
-		},
-		{
-			"name": "thomas.c.howard",
-			"location": "https://raw.githubusercontent.com/tchoward/Hubitat/master/repository.json"
-		},
-		{
-			"name": "Arn Burkhoff",
-			"location": "https://raw.githubusercontent.com/arnbme/nyckelharpa/master/repository.json"
-		},
-		{
-			"name": "Marco Felicio (maffpt@gmail.com)",
-			"location": "https://raw.githubusercontent.com/MAFFPT/Hubitat/master/Nuki%20Smart%20Lock/masterManifest.json"
-		},
-		{
-			"name": "n3!",
-			"location": "https://raw.githubusercontent.com/dmike3/Hubitat/master/hpm/repository.json"
-		},
-		{
-			"name": "lnjustin",
-			"location": "https://raw.githubusercontent.com/lnjustin/Hubitat/master/repository.json"
-		},
-		{
-			"name": "ardichoke",
-			"location": "https://raw.githubusercontent.com/ardichoke/hubitat-repo/master/repository.json"
-		},
-		{
-			"name": "christi999",
-			"location": "https://raw.githubusercontent.com/muchu999/Hubitat/master/repository.json"
-		},
-		{
-			"name": "jrfarrar",
-			"location": "https://raw.githubusercontent.com/jrfarrar/hubitat/master/jrfarrar.json"
-		},
-		{
-			"name": "mikec85",
-			"location": "https://raw.githubusercontent.com/mikec85/hubitatdrivers/master/repository.json"
-		},
-		{
-			"name": "dennypage",
-			"location": "https://raw.githubusercontent.com/dennypage/hubitat/master/hpm/repository.json"
-		},
-		{
-			"name": "Rory Jaffe",
-			"location": "https://raw.githubusercontent.com/rsjaffe/Hubitat/master/repository.json"
-		},
-		{
-			"name": "Justin Walker (augoisms)",
-			"location": "https://raw.githubusercontent.com/augoisms/hubitat/master/repository.json"
-		},
-		{
-			"name": "Joel Wetzel",
-			"location": "https://raw.githubusercontent.com/joelwetzel/HubitatPackages/master/repository.json"
-		},
-		{
-			"name": "Jo Rhett",
-			"location": "https://raw.githubusercontent.com/jorhett/Hubitat/master/repository.json"
-		},
-		{
-			"name": "craigde",
-			"location": "https://raw.githubusercontent.com/craigde/hubitat-package-manager/master/repository.json"
-		},
-		{
-			"name": "Russ Vrolyk",
-			"location": "https://raw.githubusercontent.com/rvrolyk/Hubitat/master/repository.json"
-		},
-		{
-			"name": "Reid Baldwin",
-			"location": "https://raw.githubusercontent.com/rbaldwi3/HVAC/master/HVACZoneRepository.json"
-		},
-		{
-			"name": "Chris Sader (chris.sader)",
-			"location": "https://raw.githubusercontent.com/csader/hubitat/master/repository.json"
-		},
-		{
-			"name": "mbarone",
-			"location": "https://raw.githubusercontent.com/michaelbarone/hubitat/master/packagemanager/repository.json"
-		},
-		{
-			"name": "CSteele",
-			"location": "https://raw.githubusercontent.com/csteele-PD/Hubitat-public/master/repo.json"
-		},
-		{
-			"name": "jedbro",
-			"location": "https://raw.githubusercontent.com/jedbro/Hubitat-Projects/main/repositories.json"
-		},
-		{
-			"name": "SRWhite",
-			"location": "http://hubconnect.hubitatcommunity.com/HPM/HubConnectManifest.json"
-		},
-		{
-			"name": "dkilgore90",
-			"location": "https://raw.githubusercontent.com/dkilgore90/hpm-repo/master/repository.json"
-		},
-		{
-			"name": "Eliot Stocker",
-			"location": "https://raw.githubusercontent.com/eliotstocker/hubitat-packages/main/repositories.json"
-		},
-		{
-			"name": "tomw",
-			"location": "https://raw.githubusercontent.com/tomwpublic/hpm/main/repository.json"
-		},
-		{
-			"name": "LGKApps kahn@lgk.com lgkahn-hubitat",
-			"location": "https://raw.githubusercontent.com/lgkahn/hubitat/master/LGKrepository.json"
-		},
-		{
-			"name": "Botched1",
-			"location": "https://raw.githubusercontent.com/Botched1/Hubitat/master/packages/repository.json"
-		},
-		{
-			"name": "bchubitat",
-			"location": "https://raw.githubusercontent.com/bcastellucci/hubitat/main/repository.json"
-		},
-		{
-			"name": "cjcharles0",
-			"location": "https://raw.githubusercontent.com/cjcharles0/Hubitat/master/repository.json"
-		},
-		{
-			"name": "ajones",
-			"location": "https://raw.githubusercontent.com/jonesalexr/hubitat/master/repository.json"
-		},
-		{
-			"name": "dbadge",
-			"location": "https://raw.githubusercontent.com/Gelix/HubitatTailwind/main/repository.json"
-		},
-		{
-			"name": "Ernie Miller (@ernie)",
-			"location": "https://raw.githubusercontent.com/ernie/hubitat/main/repository.json"
-		},
-		{
-			"name": "Dale Coghlan (@dcoghlan)",
-			"location": "https://raw.githubusercontent.com/dcoghlan/hubitat/main/repository.json"
-		},
-		{
-			"name": "tagyoureit",
-			"location": "https://raw.githubusercontent.com/tagyoureit/hubitat-luxor/master/repository.json"
-		},
-		{
-			"name": "TonyFleisher",
-			"location": "https://raw.githubusercontent.com/TonyFleisher/tonyfleisher-hubitat/beta/repository.json"
-		},
-		{
-			"name": "Nelson Clark",
-			"location": "https://raw.githubusercontent.com/NelsonClark/Hubitat/main/repository.json"
-		},
-		{
-			"name": "Taylor Brown (@thecloudtaylor)",
-			"location": "https://raw.githubusercontent.com/thecloudtaylor/hubitat-packages/main/repository.json"
-		},
-		{
-			"name": "Rangner FG (@rfg81)",
-			"location": "https://raw.githubusercontent.com/claudegel/Hubitat-sinope-GT125/main/repository.json"
-		},
-		{
-			"name": "ZRanger1",
-			"location": "https://raw.githubusercontent.com/zranger1/hubitat-repositories/main/repository.json"
-		},
-		{
-			"name": "John Callahan (@johndc7)",
-			"location": "https://raw.githubusercontent.com/johndc7/Hubitat/main/repository.json"
-		},
-		{
-			"name": "Jeff Page (@jtp10181)",
-			"location": "https://raw.githubusercontent.com/jtp10181/Hubitat/main/repository.json"
-		},
-		{
-			"name": "viertaxa",
-			"location": "https://raw.githubusercontent.com/viertaxa/hubitat/main/.hpm/repository.json"
-		},
-		{
-			"name": "BirdsLikeWires (@andy@dvsn.net)",
-			"location": "https://raw.githubusercontent.com/birdslikewires/hubitat/main/repository.json"
-		},
-		{
-			"name": "Doug Renze (@darthbob)",
-			"location": "https://raw.githubusercontent.com/drenze/hubitat/main/repository.json"
-		},
-		{
-			"name": "akhandok",
-			"location": "https://raw.githubusercontent.com/akhandok/adhanPlayer/master/repository.json"
-		},
-		{
-			"name": "Amos Yuen",
-			"location": "https://raw.githubusercontent.com/amosyuen/hubitat/main/repository.json"
-		},
-		{
-			"name": "Matt Hammond",
-			"location": "https://raw.githubusercontent.com/matt-hammond-001/hubitat-code/master/hpm-repository.json"
-		},
-		{
-			"name": "Neil Jackson",
-			"location": "https://raw.githubusercontent.com/neiljackson1984/SmartThingsNeil/master/hubitat_package_manager_repository.json"
-		},
-		{
-			"name": "Rob Heyes",
-			"location": "https://raw.githubusercontent.com/robheyes/hpm-packages/master/repository.json"
-		},
-		{
-			"name": "MHedish",
-			"location": "https://raw.githubusercontent.com/MHedish/Hubitat/main/repository.json"
-		},
-		{
-			"name": "droath",
-			"location": "https://raw.githubusercontent.com/droath/Hubitat/master/repository.json"
-		},
-		{
-			"name": "ymerj",
-			"location": "https://raw.githubusercontent.com/ymerj/hpm/main/repository.json"
-		},
-		{ 
-			"name": "Jean P. May, Jr.",
-			"location": "https://raw.githubusercontent.com/thebearmay/hubitat/main/thebearmayRepository.json"
-		},
-		{
-			"name": "Michael van Dam",
-			"location": "https://raw.githubusercontent.com/michaelvandam/Hubitat/master/repository.json" 
-		},
-		{
-			"name": "Snell",
-			"location": "https://www.drdsnell.com/projects/hubitat/drivers/SnellRepository.json" 
-		},
-		{
-			"name": "Vincent van Didden (@Vincentiano)",
-			"location": "https://raw.githubusercontent.com/Vincentiano/Hubitat-Repositories/main/repository.json" 
-		},
-		{
-			"name": "Awth Wathje",
-			"location": "https://raw.githubusercontent.com/awthwathje/hubitat-heatit-z-push-button-8-driver/main/repository.json"
-		},
-		{
-			"name": "ritchierich",
-			"location": "https://raw.githubusercontent.com/mlritchie/Hubitat/master/repository.json"
-		},
-		{
-			"name": "rob121",
-			"location": "https://raw.githubusercontent.com/rob121/hubitat/master/repository.json"
-		},
-		{
-			"name": "Simon Burke (sburke781)",
-			"location": "https://raw.githubusercontent.com/sburke781/hubitat/master/repository.json"
-		},
-		{
-			"name": "Minoston (sky-nie)",
-			"location": "https://raw.githubusercontent.com/sky-nie/hubitat/main/repository.json"
-		},
-		{
-			"name": "Scott Barton (sab0276)",
-			"location": "https://raw.githubusercontent.com/sab0276/Hubitat/main/repository.json"
-		},
-		{
-			"name": "Raul Martin Rodriguez (luarmr)",
-			"location": "https://raw.githubusercontent.com/luarmr/hubitat/main/repository.json"
-		},
-		{
-			"name": "dacmanj",
-			"location": "https://raw.githubusercontent.com/dacmanj/hubitat/main/repository.json"
-		},
-		{
-			"name": "Daniel Segall (dds82)",
-			"location": "https://raw.githubusercontent.com/dds82/hpm-master-manifest/main/repository.json"
-		},
-		{
-			"name": "Don Caton (dcaton)",
-			"location": "https://raw.githubusercontent.com/dcaton/Hubitat/main/repository.json"
-		},
-		{
-			"name": "kaimyn",
-			"location": "https://raw.githubusercontent.com/kaimyn/Hubitat/main/repository.json"
-		},
-		{
-			"name": "Ben Deitch (@xap)",
-			"location": "https://raw.githubusercontent.com/xap-code/hubitat/master/repository.json"
-		},
-		{
-			"name": "Community Code",
-			"location": "https://www.hubitatcommunity.com/hpm/communityrepo.json"
-		},
-		{
-			"name": "James Shimota (Shumo)",
-			"location": "https://raw.githubusercontent.com/jshimota01/hubitat/main/repository.json"
-		},
-		{
-			"name": "Eduardo Simioni",
-			"location": "https://raw.githubusercontent.com/esimioni/hubitat-hpm/main/repository.json"
-		},
-		{
-			"name": "kkossev",
-			"location": "https://raw.githubusercontent.com/kkossev/Hubitat/main/repository.json"
-		},
-		{
-			"name": "Pedro Andrade",
-			"location": "https://raw.githubusercontent.com/pedroandrade1977/hubitat/main/repository.json"
-		},
-		{
-			"name": "Simon Burke (Scruffy-Sjb)",
-			"location": "https://raw.githubusercontent.com/scruffy-sjb/Hubitat_HPM/main/repository.json"
-		},
-		{
-			"name": "DarwinsDen",
-			"location": "https://raw.githubusercontent.com/DarwinsDen/Hubitat/master/repositories.json"
-		},
-		{
-			"name": "David LaPorte",
-			"location": "https://raw.githubusercontent.com/dlaporte/Hubitat/main/repository.json"
-		},
-		{
-			"name": "Samuel C Auclair",
-			"location": "https://raw.githubusercontent.com/sacua/SinopeDriverHubitat/main/repository.json"
-		},
-		{
-			"name": "Josh Rosenberg",
-			"location": "https://raw.githubusercontent.com/rosenbergj/hubitat-shabbat-and-chag/main/repository.json"
-		},
-		{
-			"name": "Vyrolan",
-			"location": "https://raw.githubusercontent.com/Vyrolan/VyrolanHomeAutomation/main/Hubitat/repository.json"
-		},
-		{
-			"name": "dan.t",
-			"location": "https://raw.githubusercontent.com/danTapps/Hubitat/master/repository.json"
-		},
-		{
-			"name": "Gary J. Milne",
-			"location": "https://raw.githubusercontent.com/GaryMilne/Hubitat-Tasmota/main/repository.json"
-		},
-		{
-			"name": "Terrel Allen",
-			"location": "https://raw.githubusercontent.com/terrelsa13/Device-Mirror-Plus/master/repository.json"
-		},
-		{
-			"name": "Steven Barcus",
-			"location": "https://raw.githubusercontent.com/srbarcus/YoLink/master/repository.json"
-		},
-		{
-			"name": "Mike Bishop",
-			"location": "https://raw.githubusercontent.com/MikeBishop/hpm-intermediate/main/hpm-intermediate.json"
-		},
-		{
-			"name": "dJOS",
-			"location": "https://raw.githubusercontent.com/dJOS1475/Hubitat_WU_Driver/main/repository.json"
-		},
-		{
-			"name": "Sebastian YEPES (syepes)",
-			"location": "https://raw.githubusercontent.com/syepes/Hubitat/master/repository.json"
-		},
-		{
-			"name": "Mavrrick",
-			"location": "https://raw.githubusercontent.com/Mavrrick/Hubitat-by-Mavrrick/main/repository.json"
-		},
-		{
-			"name": "Art Ardolino",
-			"location": "https://raw.githubusercontent.com/ajardolino3/hubitat-ajardolino3/master/repository.json"
-		},
-		{
-			"name": "Ryan Elliott (FriedCheese2006)",
-			"location": "https://raw.githubusercontent.com/FriedCheese2006/RLE_Hubitat/main/RLE_repo.json"
-		},
-		{
-			"name": "TheMaster",
-			"location": "https://raw.githubusercontent.com/tmastersmart/hubitat-code/main/packages/repository.json"
-		},
-		{
-			"name": "Greg Billings",
-			"location": "https://raw.githubusercontent.com/diosadentro/Hubitat/main/repository.json"
-		},
-		{
-			"name": "Kris Linquist",
-			"location": "https://raw.githubusercontent.com/klinquist/hubitat-packages/main/repository.json"
-		},
-		{
-			"name": "Jean Bilodeau",
-			"location": "https://raw.githubusercontent.com/jbilodea/Hubitat/main/master/repository.json"
-		},
-		{
-			"name": "jkister",
-			"location": "https://raw.githubusercontent.com/jkister/hubitat/master/repositories.json"
-		},
-		{
-			"name": "Patrick Wogan",
-			"location": "https://raw.githubusercontent.com/wogapat/HubitatApps/main/repository.json"
-		},
-		{
-			"name": "Andrew Webster",
-			"location": "https://raw.githubusercontent.com/Andywebs/hubitat/main/repository.json"
-		},
-		{
-			"name": "Jonathan Bradshaw",
-			"location": "https://raw.githubusercontent.com/bradsjm/hubitat-drivers/main/repository.json"
-		},
-		{
-			"name": "JoKneeMo",
-			"location": "https://raw.githubusercontent.com/JoKneeMo/hubitat/main/repository.json"
-		},
-		{
-			"name": "KTriponis",
-			"location": "https://raw.githubusercontent.com/ktriponis/hubitat-packages/main/repository.json"
-		},
-		{
-			"name": "Bloodtick Jones",
-			"location": "https://raw.githubusercontent.com/bloodtick/Hubitat/main/hubitat-packages/repository.json"
-		},
-		{
-			"name": "Joe Page",
-			"location": "https://raw.githubusercontent.com/jpage4500/hubitat-drivers/master/repository.json"
-		},
-		{
-			"name": "Dan Danache",
-			"location": "https://codeberg.org/dan-danache/hubitat/raw/branch/main/repository.json"
-		},
-		{
-			"name": "Paul Hutton",
-			"location": "https://raw.githubusercontent.com/VeloWulf/hubitat-packages/main/repository.json"
-		},
-		{
-			"name": "Hugo Haas",
-			"location": "https://raw.githubusercontent.com/hugoh/hubitat-packages/master/repository.json"
-		},
-		{
-			"name": "Brian Blank",
-			"location": "https://raw.githubusercontent.com/brianblank/HubitatHaywardAquaConnect/main/hpm/repository.json"
-		},
-		{
-			"name": "Schwark Satyavolu",
-			"location": "https://raw.githubusercontent.com/schwark/hubitat-packages/main/repository.json"
-		},
-		{
-			"name": "Yonatan Striem Amit",
-			"location": "https://raw.githubusercontent.com/yonatan-mitmit/hubitat-repository/main/repository.json"
-		},
-		{
-			"name": "Ken Washington",
-			"location": "https://raw.githubusercontent.com/kewashi/HubitatPackages/master/repository.json"
-		},
-		{
-			"name": "Matthew Petro",
-			"location": "https://raw.githubusercontent.com/matthewpetro/hubitat-projects/main/repository.json"
-		},
-		{
-			"name": "wecoyote5",
-			"location": "https://raw.githubusercontent.com/wecoyote5/hubitat-MyProjects/main/repository.json"
-		},
-		{
-			"name": "Josh Lobe (@joshlobe)",
-			"location": "https://raw.githubusercontent.com/joshlobe/hubitat/main/repository.json"
-		},
-		{
-			"name": "GarthDB",
-			"location": "https://gist.githubusercontent.com/GarthDB/33d2febcf39ecfae25a49b3230fb2be7/raw/10ba85fc9694979702ab92814b398307cfdd52b4/repositories.json"
-		},
-		{
-			"name": "Jonathan Fields",
-			"location": "https://raw.githubusercontent.com/fieldsjm/Hubitat-2/master/repository.json"
-		},
-		{
-			"name": "Dan Healy (TheDanHealy)",
-			"location": "https://raw.githubusercontent.com/TheDanHealy/hubitat-rental-automator/main/repositories.json"
-		},
-		{
-			"name": "tinkorswim",
-			"location": "https://raw.githubusercontent.com/tinkorswim/hubitat-hpm-repository/main/repository.json"
-		},
-		{
-			"name": "Konnected",
-			"location": "https://raw.githubusercontent.com/konnected-io/konnected-hubitat/master/hpm-repository.json"
-		},
-		{
-			"name": "Ben Jansen",
-			"location": "https://bitbucket.org/aogail/w007-hubitat-packages/raw/master/repository.json"
-		},
-		{
-			"name": "edasque",
-			"location": "https://raw.githubusercontent.com/edasque/hubitat/main/repository.json"
-		},
-		{
-			"name": "Lyle Pakula (@lpakula)",
-			"location": "https://raw.githubusercontent.com/wir3z/hubitat/main/repository.json"
-		},
-		{
-			"name":"Rene Boer",
-			"location": "https://raw.githubusercontent.com/reneboer/Hubitat/main/hpm/respository.json"
-		},
-		{
-			"name": "Tom Schmidt",
-			"location": "https://raw.githubusercontent.com/TR-Systems/hubpub/code/repository.json"
-		},
-		{
-			"name": "Daniel Winks",
-			"location": "https://raw.githubusercontent.com/DanielWinks/Hubitat-Public/main/repository.json"
-		},
-		{
-			"name": "Maxime Boissonneault",
-			"location": "https://raw.githubusercontent.com/mboisson/Hubitat/main/repository.json"
-		},
-		{
-			"name": "ShellyUSA",
-			"location": "https://raw.githubusercontent.com/ShellyUSA/Hubitat-Drivers/master/repository.json"
-		},
-		{
-			"name": "Jaime Botero",
-			"location": "https://raw.githubusercontent.com/ljbotero/hubitat-flair-vents/main/repository.json"
-		},
-		{
-			"name": "Adrian Caramaliu",
-			"location": "https://raw.githubusercontent.com/ady624/hubitat-hpm/master/repository.json"
-		},
-		{
-			"name": "Pentalingual",
-			"location": "https://raw.githubusercontent.com/pentalingual/Hubitat/main/repository.json"
-		},
-		{
-			"name": "LinptechES1",
-			"location": "https://raw.githubusercontent.com/csteele-PD/Hubitat-public/master/linptechRepo.json"
-		},
-		{
-			"name": "Steven Dale",
-			"location": "https://raw.githubusercontent.com/tmleafs/hubitat-packages/main/repository.json"
-		},
-		{
-			"name": "Vartan Horigian",
-			"location": "https://raw.githubusercontent.com/hhorigian/mainfiles/main/repository.json"
-		},
-		{
-			"name": "Wesley M. Conner",
-			"location": "https://raw.githubusercontent.com/WesleyMConner/HpmNavigation/main/repository.json"
-		},
-		{
-			"name": "Eric Meddaugh",
-			"location": "https://raw.githubusercontent.com/x86cpu/hubitat/main/repository.json"
-		},
-		{
-			"name": "Tim Dodd",
-			"location": "https://raw.githubusercontent.com/timothydodd/hubitat-acurite-mqtt/main/repository.json"
-		},
-		{
-			"name": "Graf Technology, LLC",
-			"location": "https://raw.githubusercontent.com/graftechnology/hubitat-hpm-repository/main/repository.json"
-		},
-		{
-			"name": "corinuss",
-			"location": "https://raw.githubusercontent.com/corinuss/Hubitat_IntelliFire/main/repository.json"
-		},
-		{
-			"name": "Evan Callia",
-			"location": "https://raw.githubusercontent.com/evcallia/hubitat/refs/heads/main/hpm-repository.json"
-		},
-		{
-			"name": "Kurt Sanders (kurtsanders)",
-			"location": "https://raw.githubusercontent.com/KurtSanders/HubitatPackages/master/repository.json"
-		},
-		{
-			"name": "StarkTemplar",
-			"location": "https://raw.githubusercontent.com/StarkTemplar/Hubitat/main/repository.json"
-		},
-		{
-			"name": "Randall Norviel",
-			"location": "https://raw.githubusercontent.com/randalln/randalln-hubitat/main/repository.json"
-		},
-		{
-			"name": "WalksOnAir",
-			"location": "https://raw.githubusercontent.com/walksonair/Hubitat-Pi-hole-Virtual-Switch/main/repository.json"
-		},
-		{
-			"name": "jdc72",
-			"location": "https://raw.githubusercontent.com/jdc72/Hubitat/main/repository.json"
-		},
-		{
-			"name": "Scott Wade (swade)",
-			"location": "https://raw.githubusercontent.com/DolFan81/hubitat-packages/refs/heads/main/sWadeRepository.json"
-		},
-		{
-			"name": "mrmikeface",
-			"location": "https://raw.githubusercontent.com/mrmikeface/hubitat-package-repo/main/repository.json"
-		},
-		{
-			 "name": "TechBill",
-			 "location": "https://raw.githubusercontent.com/TechBill/hubitat-packages/master/repos/techbill/repository.json"
-		},
-		{
-			 "name": "RamSet",
-			 "location": "https://raw.githubusercontent.com/RamSet/hubitat/main/repository.json"
-		},
-		{
-			 "name": "ZoozCode",
-			 "location": "https://raw.githubusercontent.com/HubitatCommunity/ZoozCode/refs/heads/main/ZoozCode_repo.json"
-		},
-		{
-			 "name": "Boguslaw Wojcik (@bogus.wojcik)",
-			 "location": "https://raw.githubusercontent.com/boguslaw-wojcik/hubitat/main/repository.json"
-		},
-		{
-			"name": "ke7lvb",
-			"location": "https://raw.githubusercontent.com/ke7lvb/ke7lvb/refs/heads/main/repository.json"
-		},
-		{
-			"name": "Jeffrey Zimmerman's Hubitat Apps",
-			"location": "https://raw.githubusercontent.com/JeffreyZimms/Home-Environment-Aggregator/main/repository.json"
-		},
-		{
-			"name": "spinrag",
-			"location": "https://raw.githubusercontent.com/spinrag/hubitat/main/repository.json"
-		},
-		{
-			"name": "SORS",
-			"location": "https://raw.githubusercontent.com/sorsme/sinope-switch/main/repository.json"
-		},
-		{
-			"name": "jonozzz",
-			"location": "https://raw.githubusercontent.com/jonozzz/hubitat-thinqconnect/refs/heads/main/repository.json"
-		},
-		{
-			"name": "jschlackman",
-			"location": "https://raw.githubusercontent.com/jschlackman/Hubitat/main/repository.json"
-		},
-		{
-			"name": "Mathew Beall",
-			"location": "https://raw.githubusercontent.com/mathewbeall/hubitat-resideo_T10-integration/main/repository.json"
-		},
-		{
-			"name": "obeisser",
-			"location": "https://raw.githubusercontent.com/obeisser/hubitat-drivers/main/repository.json"
-		},
-		{
-			"name": "WarlockWeary",
-			"location": "https://raw.githubusercontent.com/Warlock-Weary/Light.Security.Monitor/main/repository.json"
-		},
-		{
-			"name": "vpsupun",
-			"location": "https://raw.githubusercontent.com/vpsupun/hubitat/master/repository.json"
-		},
-		{
-			"name": "curtiside",
-			"location": "https://raw.githubusercontent.com/curtiside/oelo-lights-hubitat/main/repository.json"
-		},
-		{
-			"name": "Electrified-Home",
-			"location": "https://raw.githubusercontent.com/Electrified-Home/Hubitat-Advanced-Heliotrope/main/repository.json"
-		},
-		{
-			"name": "Albert Mulder",
-			"location": "https://raw.githubusercontent.com/almulder/Hubitat-Drivers/refs/heads/main/hpm/repository.json"
-		},
-		{
-			"name": "aniva",
-			"location": "https://raw.githubusercontent.com/aniva/hubitat01/refs/heads/master/repository.json"
-		},
-		{
-			"name": "Paul Harrison",
-			"location": "https://raw.githubusercontent.com/pharrison5/Hubitat/refs/heads/main/repository.json"
-		},
-		{
-			"name": "truittchris",
-			"location": "https://raw.githubusercontent.com/truittchris/hubitat-hpm/main/repository.json"
-		},
-		{
-    			"name": "signal15",
-    			"location": "https://raw.githubusercontent.com/signal15/tuya-minisplit-hubitat/main/repository.json"
-		},
-		{
- 			"name": "jlupien",
-			"location": "https://raw.githubusercontent.com/jlupien/hubitat-drivers/refs/heads/master/repository.json"
-		},
-		{
-			"name": "Mathew Beall",
-			"location": "https://raw.githubusercontent.com/mathewbeall/hubitat-xsense-integration/main/repository.json"
-		},
-		{
-			"name": "kingpanther13",
-			"location": "https://raw.githubusercontent.com/kingpanther13/Hubitat-local-MCP-server/main/repository.json"
-		},
-		{
-			"name": "WindowWasher",
-			"location": "https://raw.githubusercontent.com/tyuhl/Hubitat-Packages/refs/heads/main/repository.json"
-		},
-		{
-			"name": "HERMES Automation",
-			"location": "https://hermes-automation.com/app-code/home-dispatch/hubitat/manifests/repository.json"
-		},
-		{
-			"name": "rbyrbt",
-			"location": "https://raw.githubusercontent.com/rbyrbt/Hubitat/main/repository.json"
-		},
-		{
-			"name": "ogiewon",
-			"location": "https://raw.githubusercontent.com/ogiewon/Hubitat/refs/heads/master/repository.json"
-		},
-		{
-			"name": "Jdthomas24",
-			"location": "https://raw.githubusercontent.com/jdthomas24/Hubitat-Apps/refs/heads/main/repo.json"
-		},
-		{
- 			"name": "Haven",
-  			"location": "https://raw.githubusercontent.com/h4ven88/hestia-dashboard/main/repository.json"
-		},
-		{
-			"name": "brossow",
-			"location": "https://raw.githubusercontent.com/brossow/hubitat-econet/main/repository.json"
-		},
-		{
-			"name": "uDevel",
-			"location": "https://raw.githubusercontent.com/uDevel/hubitat-soma-shades-3/main/repository.json"
-		}
-	],
-	"hpm": {
-		"location": "https://raw.githubusercontent.com/HubitatCommunity/hubitatpackagemanager/main/packageManifest.json"
-	}
+    "repositories": [
+        {
+            "name": "dman2306",
+            "location": "https://raw.githubusercontent.com/dcmeglio/hubitat-packages/master/repository.json"
+        },
+        {
+            "name": "Victor Santana (Welasco)",
+            "location": "https://raw.githubusercontent.com/Welasco/hubitat/master/repository.json"
+        },
+        {
+            "name": "Ramdev Shallem",
+            "location": "https://raw.githubusercontent.com/gilshallem/Hubitat/main/HPM/repositories.json"
+        },
+        {
+            "name": "BPTWorld",
+            "location": "https://raw.githubusercontent.com/bptworld/Hubitat/master/repositories.json"
+        },
+        {
+            "name": "AaronW",
+            "location": "https://raw.githubusercontent.com/PrayerfulDrop/Hubitat/master/repository.json"
+        },
+        {
+            "name": "bcopeland",
+            "location": "https://raw.githubusercontent.com/djdizzyd/hubitat/master/packages/repositories.json"
+        },
+        {
+            "name": "heidrickla (Lewis.Heidrick)",
+            "location": "https://raw.githubusercontent.com/heidrickla/Hubitat/main/Docs/repository.json"
+        },
+        {
+            "name": "storageaanarchy (SANdood)",
+            "location": "https://raw.githubusercontent.com/SANdood/Hubitat-Stuff/master/repository.json"
+        },
+        {
+            "name": "RMoRobert (BertABCD1234)",
+            "location": "https://raw.githubusercontent.com/RMoRobert/Hubitat/master/repository.json"
+        },
+        {
+            "name": "Dave Gutheinz(DavGut)",
+            "location": "https://raw.githubusercontent.com/DaveGut/HubitatActive/master/repository.json"
+        },
+        {
+            "name": "Matthew (@scottma61)",
+            "location": "https://raw.githubusercontent.com/Scottma61/Hubitat/master/docs/Matthew_repository.json"
+        },
+        {
+            "name": "Miles Budnek (@mbudnek)",
+            "location": "https://raw.githubusercontent.com/mbudnek/hubitat-package-manager-repo/master/repository.json"
+        },
+        {
+            "name": "Inovelli",
+            "location": "https://raw.githubusercontent.com/InovelliUSA/Hubitat/master/repository.json"
+        },
+        {
+            "name": "Markus (@markus)",
+            "location": "https://raw.githubusercontent.com/markus-li/Hubitat/release/repository.json"
+        },
+        {
+            "name": "Joseph Kregloh",
+            "location": "https://raw.githubusercontent.com/funzie19/hubitat-solaredge/master/repositories.json"
+        },
+        {
+            "name": "Anthony S. (tonesto7)",
+            "location": "https://raw.githubusercontent.com/tonesto7/hubitat/master/repository.json"
+        },
+        {
+            "name": "MFornander",
+            "location": "https://raw.githubusercontent.com/MFornander/Hubitat/master/respository.json"
+        },
+        {
+            "name": "imnotbob",
+            "location": "https://raw.githubusercontent.com/imnotbob/webCoRE/hubitat-patches/HE/repository.json"
+        },
+        {
+            "name": "nh.schottfam",
+            "location": "https://raw.githubusercontent.com/imnotbob/Hubitat-Intesis/master/repository.json"
+        },
+        {
+            "name": "apwelsh",
+            "location": "https://raw.githubusercontent.com/apwelsh/hubitat/master/repository.json"
+        },
+        {
+            "name": "bsileo",
+            "location": "https://raw.githubusercontent.com/bsileo/hubitat_poolcontroller/master/repository.json"
+        },
+        {
+            "name": "Brian Wilson (@brianwilson)",
+            "location": "https://raw.githubusercontent.com/bdwilson/hubitat/master/repository.json"
+        },
+        {
+            "name": "napalmcsr",
+            "location": "https://raw.githubusercontent.com/napalmcsr/Hubitat_Napalmcsr/master/docs/HPM.json"
+        },
+        {
+            "name": "thomas.c.howard",
+            "location": "https://raw.githubusercontent.com/tchoward/Hubitat/master/repository.json"
+        },
+        {
+            "name": "Arn Burkhoff",
+            "location": "https://raw.githubusercontent.com/arnbme/nyckelharpa/master/repository.json"
+        },
+        {
+            "name": "Marco Felicio (maffpt@gmail.com)",
+            "location": "https://raw.githubusercontent.com/MAFFPT/Hubitat/master/Nuki%20Smart%20Lock/masterManifest.json"
+        },
+        {
+            "name": "n3!",
+            "location": "https://raw.githubusercontent.com/dmike3/Hubitat/master/hpm/repository.json"
+        },
+        {
+            "name": "lnjustin",
+            "location": "https://raw.githubusercontent.com/lnjustin/Hubitat/master/repository.json"
+        },
+        {
+            "name": "ardichoke",
+            "location": "https://raw.githubusercontent.com/ardichoke/hubitat-repo/master/repository.json"
+        },
+        {
+            "name": "christi999",
+            "location": "https://raw.githubusercontent.com/muchu999/Hubitat/master/repository.json"
+        },
+        {
+            "name": "jrfarrar",
+            "location": "https://raw.githubusercontent.com/jrfarrar/hubitat/master/jrfarrar.json"
+        },
+        {
+            "name": "mikec85",
+            "location": "https://raw.githubusercontent.com/mikec85/hubitatdrivers/master/repository.json"
+        },
+        {
+            "name": "dennypage",
+            "location": "https://raw.githubusercontent.com/dennypage/hubitat/master/hpm/repository.json"
+        },
+        {
+            "name": "Rory Jaffe",
+            "location": "https://raw.githubusercontent.com/rsjaffe/Hubitat/master/repository.json"
+        },
+        {
+            "name": "Justin Walker (augoisms)",
+            "location": "https://raw.githubusercontent.com/augoisms/hubitat/master/repository.json"
+        },
+        {
+            "name": "Joel Wetzel",
+            "location": "https://raw.githubusercontent.com/joelwetzel/HubitatPackages/master/repository.json"
+        },
+        {
+            "name": "Jo Rhett",
+            "location": "https://raw.githubusercontent.com/jorhett/Hubitat/master/repository.json"
+        },
+        {
+            "name": "craigde",
+            "location": "https://raw.githubusercontent.com/craigde/hubitat-package-manager/master/repository.json"
+        },
+        {
+            "name": "Russ Vrolyk",
+            "location": "https://raw.githubusercontent.com/rvrolyk/Hubitat/master/repository.json"
+        },
+        {
+            "name": "Reid Baldwin",
+            "location": "https://raw.githubusercontent.com/rbaldwi3/HVAC/master/HVACZoneRepository.json"
+        },
+        {
+            "name": "Chris Sader (chris.sader)",
+            "location": "https://raw.githubusercontent.com/csader/hubitat/master/repository.json"
+        },
+        {
+            "name": "mbarone",
+            "location": "https://raw.githubusercontent.com/michaelbarone/hubitat/master/packagemanager/repository.json"
+        },
+        {
+            "name": "CSteele",
+            "location": "https://raw.githubusercontent.com/csteele-PD/Hubitat-public/master/repo.json"
+        },
+        {
+            "name": "jedbro",
+            "location": "https://raw.githubusercontent.com/jedbro/Hubitat-Projects/main/repositories.json"
+        },
+        {
+            "name": "SRWhite",
+            "location": "http://hubconnect.hubitatcommunity.com/HPM/HubConnectManifest.json"
+        },
+        {
+            "name": "dkilgore90",
+            "location": "https://raw.githubusercontent.com/dkilgore90/hpm-repo/master/repository.json"
+        },
+        {
+            "name": "Eliot Stocker",
+            "location": "https://raw.githubusercontent.com/eliotstocker/hubitat-packages/main/repositories.json"
+        },
+        {
+            "name": "tomw",
+            "location": "https://raw.githubusercontent.com/tomwpublic/hpm/main/repository.json"
+        },
+        {
+            "name": "LGKApps kahn@lgk.com lgkahn-hubitat",
+            "location": "https://raw.githubusercontent.com/lgkahn/hubitat/master/LGKrepository.json"
+        },
+        {
+            "name": "Botched1",
+            "location": "https://raw.githubusercontent.com/Botched1/Hubitat/master/packages/repository.json"
+        },
+        {
+            "name": "bchubitat",
+            "location": "https://raw.githubusercontent.com/bcastellucci/hubitat/main/repository.json"
+        },
+        {
+            "name": "cjcharles0",
+            "location": "https://raw.githubusercontent.com/cjcharles0/Hubitat/master/repository.json"
+        },
+        {
+            "name": "ajones",
+            "location": "https://raw.githubusercontent.com/jonesalexr/hubitat/master/repository.json"
+        },
+        {
+            "name": "dbadge",
+            "location": "https://raw.githubusercontent.com/Gelix/HubitatTailwind/main/repository.json"
+        },
+        {
+            "name": "Ernie Miller (@ernie)",
+            "location": "https://raw.githubusercontent.com/ernie/hubitat/main/repository.json"
+        },
+        {
+            "name": "Dale Coghlan (@dcoghlan)",
+            "location": "https://raw.githubusercontent.com/dcoghlan/hubitat/main/repository.json"
+        },
+        {
+            "name": "tagyoureit",
+            "location": "https://raw.githubusercontent.com/tagyoureit/hubitat-luxor/master/repository.json"
+        },
+        {
+            "name": "TonyFleisher",
+            "location": "https://raw.githubusercontent.com/TonyFleisher/tonyfleisher-hubitat/beta/repository.json"
+        },
+        {
+            "name": "Nelson Clark",
+            "location": "https://raw.githubusercontent.com/NelsonClark/Hubitat/main/repository.json"
+        },
+        {
+            "name": "Taylor Brown (@thecloudtaylor)",
+            "location": "https://raw.githubusercontent.com/thecloudtaylor/hubitat-packages/main/repository.json"
+        },
+        {
+            "name": "Rangner FG (@rfg81)",
+            "location": "https://raw.githubusercontent.com/claudegel/Hubitat-sinope-GT125/main/repository.json"
+        },
+        {
+            "name": "ZRanger1",
+            "location": "https://raw.githubusercontent.com/zranger1/hubitat-repositories/main/repository.json"
+        },
+        {
+            "name": "John Callahan (@johndc7)",
+            "location": "https://raw.githubusercontent.com/johndc7/Hubitat/main/repository.json"
+        },
+        {
+            "name": "Jeff Page (@jtp10181)",
+            "location": "https://raw.githubusercontent.com/jtp10181/Hubitat/main/repository.json"
+        },
+        {
+            "name": "viertaxa",
+            "location": "https://raw.githubusercontent.com/viertaxa/hubitat/main/.hpm/repository.json"
+        },
+        {
+            "name": "BirdsLikeWires (@andy@dvsn.net)",
+            "location": "https://raw.githubusercontent.com/birdslikewires/hubitat/main/repository.json"
+        },
+        {
+            "name": "Doug Renze (@darthbob)",
+            "location": "https://raw.githubusercontent.com/drenze/hubitat/main/repository.json"
+        },
+        {
+            "name": "akhandok",
+            "location": "https://raw.githubusercontent.com/akhandok/adhanPlayer/master/repository.json"
+        },
+        {
+            "name": "Amos Yuen",
+            "location": "https://raw.githubusercontent.com/amosyuen/hubitat/main/repository.json"
+        },
+        {
+            "name": "Matt Hammond",
+            "location": "https://raw.githubusercontent.com/matt-hammond-001/hubitat-code/master/hpm-repository.json"
+        },
+        {
+            "name": "Neil Jackson",
+            "location": "https://raw.githubusercontent.com/neiljackson1984/SmartThingsNeil/master/hubitat_package_manager_repository.json"
+        },
+        {
+            "name": "Rob Heyes",
+            "location": "https://raw.githubusercontent.com/robheyes/hpm-packages/master/repository.json"
+        },
+        {
+            "name": "MHedish",
+            "location": "https://raw.githubusercontent.com/MHedish/Hubitat/main/repository.json"
+        },
+        {
+            "name": "droath",
+            "location": "https://raw.githubusercontent.com/droath/Hubitat/master/repository.json"
+        },
+        {
+            "name": "ymerj",
+            "location": "https://raw.githubusercontent.com/ymerj/hpm/main/repository.json"
+        },
+        {
+            "name": "Jean P. May, Jr.",
+            "location": "https://raw.githubusercontent.com/thebearmay/hubitat/main/thebearmayRepository.json"
+        },
+        {
+            "name": "Michael van Dam",
+            "location": "https://raw.githubusercontent.com/michaelvandam/Hubitat/master/repository.json"
+        },
+        {
+            "name": "Snell",
+            "location": "https://www.drdsnell.com/projects/hubitat/drivers/SnellRepository.json"
+        },
+        {
+            "name": "Vincent van Didden (@Vincentiano)",
+            "location": "https://raw.githubusercontent.com/Vincentiano/Hubitat-Repositories/main/repository.json"
+        },
+        {
+            "name": "Awth Wathje",
+            "location": "https://raw.githubusercontent.com/awthwathje/hubitat-heatit-z-push-button-8-driver/main/repository.json"
+        },
+        {
+            "name": "ritchierich",
+            "location": "https://raw.githubusercontent.com/mlritchie/Hubitat/master/repository.json"
+        },
+        {
+            "name": "rob121",
+            "location": "https://raw.githubusercontent.com/rob121/hubitat/master/repository.json"
+        },
+        {
+            "name": "Simon Burke (sburke781)",
+            "location": "https://raw.githubusercontent.com/sburke781/hubitat/master/repository.json"
+        },
+        {
+            "name": "Minoston (sky-nie)",
+            "location": "https://raw.githubusercontent.com/sky-nie/hubitat/main/repository.json"
+        },
+        {
+            "name": "Scott Barton (sab0276)",
+            "location": "https://raw.githubusercontent.com/sab0276/Hubitat/main/repository.json"
+        },
+        {
+            "name": "Raul Martin Rodriguez (luarmr)",
+            "location": "https://raw.githubusercontent.com/luarmr/hubitat/main/repository.json"
+        },
+        {
+            "name": "dacmanj",
+            "location": "https://raw.githubusercontent.com/dacmanj/hubitat/main/repository.json"
+        },
+        {
+            "name": "Daniel Segall (dds82)",
+            "location": "https://raw.githubusercontent.com/dds82/hpm-master-manifest/main/repository.json"
+        },
+        {
+            "name": "Don Caton (dcaton)",
+            "location": "https://raw.githubusercontent.com/dcaton/Hubitat/main/repository.json"
+        },
+        {
+            "name": "kaimyn",
+            "location": "https://raw.githubusercontent.com/kaimyn/Hubitat/main/repository.json"
+        },
+        {
+            "name": "Ben Deitch (@xap)",
+            "location": "https://raw.githubusercontent.com/xap-code/hubitat/master/repository.json"
+        },
+        {
+            "name": "Community Code",
+            "location": "https://www.hubitatcommunity.com/hpm/communityrepo.json"
+        },
+        {
+            "name": "James Shimota (Shumo)",
+            "location": "https://raw.githubusercontent.com/jshimota01/hubitat/main/repository.json"
+        },
+        {
+            "name": "Eduardo Simioni",
+            "location": "https://raw.githubusercontent.com/esimioni/hubitat-hpm/main/repository.json"
+        },
+        {
+            "name": "kkossev",
+            "location": "https://raw.githubusercontent.com/kkossev/Hubitat/main/repository.json"
+        },
+        {
+            "name": "Pedro Andrade",
+            "location": "https://raw.githubusercontent.com/pedroandrade1977/hubitat/main/repository.json"
+        },
+        {
+            "name": "Simon Burke (Scruffy-Sjb)",
+            "location": "https://raw.githubusercontent.com/scruffy-sjb/Hubitat_HPM/main/repository.json"
+        },
+        {
+            "name": "DarwinsDen",
+            "location": "https://raw.githubusercontent.com/DarwinsDen/Hubitat/master/repositories.json"
+        },
+        {
+            "name": "David LaPorte",
+            "location": "https://raw.githubusercontent.com/dlaporte/Hubitat/main/repository.json"
+        },
+        {
+            "name": "Samuel C Auclair",
+            "location": "https://raw.githubusercontent.com/sacua/SinopeDriverHubitat/main/repository.json"
+        },
+        {
+            "name": "Josh Rosenberg",
+            "location": "https://raw.githubusercontent.com/rosenbergj/hubitat-shabbat-and-chag/main/repository.json"
+        },
+        {
+            "name": "Vyrolan",
+            "location": "https://raw.githubusercontent.com/Vyrolan/VyrolanHomeAutomation/main/Hubitat/repository.json"
+        },
+        {
+            "name": "dan.t",
+            "location": "https://raw.githubusercontent.com/danTapps/Hubitat/master/repository.json"
+        },
+        {
+            "name": "Gary J. Milne",
+            "location": "https://raw.githubusercontent.com/GaryMilne/Hubitat-Tasmota/main/repository.json"
+        },
+        {
+            "name": "Terrel Allen",
+            "location": "https://raw.githubusercontent.com/terrelsa13/Device-Mirror-Plus/master/repository.json"
+        },
+        {
+            "name": "Steven Barcus",
+            "location": "https://raw.githubusercontent.com/srbarcus/YoLink/master/repository.json"
+        },
+        {
+            "name": "Mike Bishop",
+            "location": "https://raw.githubusercontent.com/MikeBishop/hpm-intermediate/main/hpm-intermediate.json"
+        },
+        {
+            "name": "dJOS",
+            "location": "https://raw.githubusercontent.com/dJOS1475/Hubitat_WU_Driver/main/repository.json"
+        },
+        {
+            "name": "Sebastian YEPES (syepes)",
+            "location": "https://raw.githubusercontent.com/syepes/Hubitat/master/repository.json"
+        },
+        {
+            "name": "Mavrrick",
+            "location": "https://raw.githubusercontent.com/Mavrrick/Hubitat-by-Mavrrick/main/repository.json"
+        },
+        {
+            "name": "Art Ardolino",
+            "location": "https://raw.githubusercontent.com/ajardolino3/hubitat-ajardolino3/master/repository.json"
+        },
+        {
+            "name": "Ryan Elliott (FriedCheese2006)",
+            "location": "https://raw.githubusercontent.com/FriedCheese2006/RLE_Hubitat/main/RLE_repo.json"
+        },
+        {
+            "name": "TheMaster",
+            "location": "https://raw.githubusercontent.com/tmastersmart/hubitat-code/main/packages/repository.json"
+        },
+        {
+            "name": "Greg Billings",
+            "location": "https://raw.githubusercontent.com/diosadentro/Hubitat/main/repository.json"
+        },
+        {
+            "name": "Kris Linquist",
+            "location": "https://raw.githubusercontent.com/klinquist/hubitat-packages/main/repository.json"
+        },
+        {
+            "name": "Jean Bilodeau",
+            "location": "https://raw.githubusercontent.com/jbilodea/Hubitat/main/master/repository.json"
+        },
+        {
+            "name": "jkister",
+            "location": "https://raw.githubusercontent.com/jkister/hubitat/master/repositories.json"
+        },
+        {
+            "name": "Patrick Wogan",
+            "location": "https://raw.githubusercontent.com/wogapat/HubitatApps/main/repository.json"
+        },
+        {
+            "name": "Andrew Webster",
+            "location": "https://raw.githubusercontent.com/Andywebs/hubitat/main/repository.json"
+        },
+        {
+            "name": "Jonathan Bradshaw",
+            "location": "https://raw.githubusercontent.com/bradsjm/hubitat-drivers/main/repository.json"
+        },
+        {
+            "name": "JoKneeMo",
+            "location": "https://raw.githubusercontent.com/JoKneeMo/hubitat/main/repository.json"
+        },
+        {
+            "name": "KTriponis",
+            "location": "https://raw.githubusercontent.com/ktriponis/hubitat-packages/main/repository.json"
+        },
+        {
+            "name": "Bloodtick Jones",
+            "location": "https://raw.githubusercontent.com/bloodtick/Hubitat/main/hubitat-packages/repository.json"
+        },
+        {
+            "name": "Joe Page",
+            "location": "https://raw.githubusercontent.com/jpage4500/hubitat-drivers/master/repository.json"
+        },
+        {
+            "name": "Dan Danache",
+            "location": "https://codeberg.org/dan-danache/hubitat/raw/branch/main/repository.json"
+        },
+        {
+            "name": "Paul Hutton",
+            "location": "https://raw.githubusercontent.com/VeloWulf/hubitat-packages/main/repository.json"
+        },
+        {
+            "name": "Hugo Haas",
+            "location": "https://raw.githubusercontent.com/hugoh/hubitat-packages/master/repository.json"
+        },
+        {
+            "name": "Brian Blank",
+            "location": "https://raw.githubusercontent.com/brianblank/HubitatHaywardAquaConnect/main/hpm/repository.json"
+        },
+        {
+            "name": "Schwark Satyavolu",
+            "location": "https://raw.githubusercontent.com/schwark/hubitat-packages/main/repository.json"
+        },
+        {
+            "name": "Yonatan Striem Amit",
+            "location": "https://raw.githubusercontent.com/yonatan-mitmit/hubitat-repository/main/repository.json"
+        },
+        {
+            "name": "Ken Washington",
+            "location": "https://raw.githubusercontent.com/kewashi/HubitatPackages/master/repository.json"
+        },
+        {
+            "name": "Matthew Petro",
+            "location": "https://raw.githubusercontent.com/matthewpetro/hubitat-projects/main/repository.json"
+        },
+        {
+            "name": "wecoyote5",
+            "location": "https://raw.githubusercontent.com/wecoyote5/hubitat-MyProjects/main/repository.json"
+        },
+        {
+            "name": "Josh Lobe (@joshlobe)",
+            "location": "https://raw.githubusercontent.com/joshlobe/hubitat/main/repository.json"
+        },
+        {
+            "name": "GarthDB",
+            "location": "https://gist.githubusercontent.com/GarthDB/33d2febcf39ecfae25a49b3230fb2be7/raw/10ba85fc9694979702ab92814b398307cfdd52b4/repositories.json"
+        },
+        {
+            "name": "Jonathan Fields",
+            "location": "https://raw.githubusercontent.com/fieldsjm/Hubitat-2/master/repository.json"
+        },
+        {
+            "name": "Dan Healy (TheDanHealy)",
+            "location": "https://raw.githubusercontent.com/TheDanHealy/hubitat-rental-automator/main/repositories.json"
+        },
+        {
+            "name": "tinkorswim",
+            "location": "https://raw.githubusercontent.com/tinkorswim/hubitat-hpm-repository/main/repository.json"
+        },
+        {
+            "name": "Konnected",
+            "location": "https://raw.githubusercontent.com/konnected-io/konnected-hubitat/master/hpm-repository.json"
+        },
+        {
+            "name": "Ben Jansen",
+            "location": "https://bitbucket.org/aogail/w007-hubitat-packages/raw/master/repository.json"
+        },
+        {
+            "name": "edasque",
+            "location": "https://raw.githubusercontent.com/edasque/hubitat/main/repository.json"
+        },
+        {
+            "name": "Lyle Pakula (@lpakula)",
+            "location": "https://raw.githubusercontent.com/wir3z/hubitat/main/repository.json"
+        },
+        {
+            "name": "Rene Boer",
+            "location": "https://raw.githubusercontent.com/reneboer/Hubitat/main/hpm/respository.json"
+        },
+        {
+            "name": "Tom Schmidt",
+            "location": "https://raw.githubusercontent.com/TR-Systems/hubpub/code/repository.json"
+        },
+        {
+            "name": "Daniel Winks",
+            "location": "https://raw.githubusercontent.com/DanielWinks/Hubitat-Public/main/repository.json"
+        },
+        {
+            "name": "Maxime Boissonneault",
+            "location": "https://raw.githubusercontent.com/mboisson/Hubitat/main/repository.json"
+        },
+        {
+            "name": "ShellyUSA",
+            "location": "https://raw.githubusercontent.com/ShellyUSA/Hubitat-Drivers/master/repository.json"
+        },
+        {
+            "name": "Jaime Botero",
+            "location": "https://raw.githubusercontent.com/ljbotero/hubitat-flair-vents/main/repository.json"
+        },
+        {
+            "name": "Adrian Caramaliu",
+            "location": "https://raw.githubusercontent.com/ady624/hubitat-hpm/master/repository.json"
+        },
+        {
+            "name": "Pentalingual",
+            "location": "https://raw.githubusercontent.com/pentalingual/Hubitat/main/repository.json"
+        },
+        {
+            "name": "LinptechES1",
+            "location": "https://raw.githubusercontent.com/csteele-PD/Hubitat-public/master/linptechRepo.json"
+        },
+        {
+            "name": "Steven Dale",
+            "location": "https://raw.githubusercontent.com/tmleafs/hubitat-packages/main/repository.json"
+        },
+        {
+            "name": "Vartan Horigian",
+            "location": "https://raw.githubusercontent.com/hhorigian/mainfiles/main/repository.json"
+        },
+        {
+            "name": "Wesley M. Conner",
+            "location": "https://raw.githubusercontent.com/WesleyMConner/HpmNavigation/main/repository.json"
+        },
+        {
+            "name": "Eric Meddaugh",
+            "location": "https://raw.githubusercontent.com/x86cpu/hubitat/main/repository.json"
+        },
+        {
+            "name": "Tim Dodd",
+            "location": "https://raw.githubusercontent.com/timothydodd/hubitat-acurite-mqtt/main/repository.json"
+        },
+        {
+            "name": "Graf Technology, LLC",
+            "location": "https://raw.githubusercontent.com/graftechnology/hubitat-hpm-repository/main/repository.json"
+        },
+        {
+            "name": "corinuss",
+            "location": "https://raw.githubusercontent.com/corinuss/Hubitat_IntelliFire/main/repository.json"
+        },
+        {
+            "name": "Evan Callia",
+            "location": "https://raw.githubusercontent.com/evcallia/hubitat/refs/heads/main/hpm-repository.json"
+        },
+        {
+            "name": "Kurt Sanders (kurtsanders)",
+            "location": "https://raw.githubusercontent.com/KurtSanders/HubitatPackages/master/repository.json"
+        },
+        {
+            "name": "StarkTemplar",
+            "location": "https://raw.githubusercontent.com/StarkTemplar/Hubitat/main/repository.json"
+        },
+        {
+            "name": "Randall Norviel",
+            "location": "https://raw.githubusercontent.com/randalln/randalln-hubitat/main/repository.json"
+        },
+        {
+            "name": "WalksOnAir",
+            "location": "https://raw.githubusercontent.com/walksonair/Hubitat-Pi-hole-Virtual-Switch/main/repository.json"
+        },
+        {
+            "name": "jdc72",
+            "location": "https://raw.githubusercontent.com/jdc72/Hubitat/main/repository.json"
+        },
+        {
+            "name": "Scott Wade (swade)",
+            "location": "https://raw.githubusercontent.com/DolFan81/hubitat-packages/refs/heads/main/sWadeRepository.json"
+        },
+        {
+            "name": "mrmikeface",
+            "location": "https://raw.githubusercontent.com/mrmikeface/hubitat-package-repo/main/repository.json"
+        },
+        {
+            "name": "TechBill",
+            "location": "https://raw.githubusercontent.com/TechBill/hubitat-packages/master/repos/techbill/repository.json"
+        },
+        {
+            "name": "RamSet",
+            "location": "https://raw.githubusercontent.com/RamSet/hubitat/main/repository.json"
+        },
+        {
+            "name": "ZoozCode",
+            "location": "https://raw.githubusercontent.com/HubitatCommunity/ZoozCode/refs/heads/main/ZoozCode_repo.json"
+        },
+        {
+            "name": "Boguslaw Wojcik (@bogus.wojcik)",
+            "location": "https://raw.githubusercontent.com/boguslaw-wojcik/hubitat/main/repository.json"
+        },
+        {
+            "name": "ke7lvb",
+            "location": "https://raw.githubusercontent.com/ke7lvb/ke7lvb/refs/heads/main/repository.json"
+        },
+        {
+            "name": "Jeffrey Zimmerman's Hubitat Apps",
+            "location": "https://raw.githubusercontent.com/JeffreyZimms/Home-Environment-Aggregator/main/repository.json"
+        },
+        {
+            "name": "spinrag",
+            "location": "https://raw.githubusercontent.com/spinrag/hubitat/main/repository.json"
+        },
+        {
+            "name": "SORS",
+            "location": "https://raw.githubusercontent.com/sorsme/sinope-switch/main/repository.json"
+        },
+        {
+            "name": "jonozzz",
+            "location": "https://raw.githubusercontent.com/jonozzz/hubitat-thinqconnect/refs/heads/main/repository.json"
+        },
+        {
+            "name": "jschlackman",
+            "location": "https://raw.githubusercontent.com/jschlackman/Hubitat/main/repository.json"
+        },
+        {
+            "name": "Mathew Beall",
+            "location": "https://raw.githubusercontent.com/mathewbeall/hubitat-resideo_T10-integration/main/repository.json"
+        },
+        {
+            "name": "obeisser",
+            "location": "https://raw.githubusercontent.com/obeisser/hubitat-drivers/main/repository.json"
+        },
+        {
+            "name": "WarlockWeary",
+            "location": "https://raw.githubusercontent.com/Warlock-Weary/Light.Security.Monitor/main/repository.json"
+        },
+        {
+            "name": "vpsupun",
+            "location": "https://raw.githubusercontent.com/vpsupun/hubitat/master/repository.json"
+        },
+        {
+            "name": "curtiside",
+            "location": "https://raw.githubusercontent.com/curtiside/oelo-lights-hubitat/main/repository.json"
+        },
+        {
+            "name": "Electrified-Home",
+            "location": "https://raw.githubusercontent.com/Electrified-Home/Hubitat-Advanced-Heliotrope/main/repository.json"
+        },
+        {
+            "name": "Albert Mulder",
+            "location": "https://raw.githubusercontent.com/almulder/Hubitat-Drivers/refs/heads/main/hpm/repository.json"
+        },
+        {
+            "name": "aniva",
+            "location": "https://raw.githubusercontent.com/aniva/hubitat01/refs/heads/master/repository.json"
+        },
+        {
+            "name": "Paul Harrison",
+            "location": "https://raw.githubusercontent.com/pharrison5/Hubitat/refs/heads/main/repository.json"
+        },
+        {
+            "name": "truittchris",
+            "location": "https://raw.githubusercontent.com/truittchris/hubitat-hpm/main/repository.json"
+        },
+        {
+            "name": "signal15",
+            "location": "https://raw.githubusercontent.com/signal15/tuya-minisplit-hubitat/main/repository.json"
+        },
+        {
+            "name": "jlupien",
+            "location": "https://raw.githubusercontent.com/jlupien/hubitat-drivers/refs/heads/master/repository.json"
+        },
+        {
+            "name": "Mathew Beall",
+            "location": "https://raw.githubusercontent.com/mathewbeall/hubitat-xsense-integration/main/repository.json"
+        },
+        {
+            "name": "kingpanther13",
+            "location": "https://raw.githubusercontent.com/kingpanther13/Hubitat-local-MCP-server/main/repository.json"
+        },
+        {
+            "name": "WindowWasher",
+            "location": "https://raw.githubusercontent.com/tyuhl/Hubitat-Packages/refs/heads/main/repository.json"
+        },
+        {
+            "name": "HERMES Automation",
+            "location": "https://hermes-automation.com/app-code/home-dispatch/hubitat/manifests/repository.json"
+        },
+        {
+            "name": "rbyrbt",
+            "location": "https://raw.githubusercontent.com/rbyrbt/Hubitat/main/repository.json"
+        },
+        {
+            "name": "ogiewon",
+            "location": "https://raw.githubusercontent.com/ogiewon/Hubitat/refs/heads/master/repository.json"
+        },
+        {
+            "name": "Jdthomas24",
+            "location": "https://raw.githubusercontent.com/jdthomas24/Hubitat-Apps/refs/heads/main/repo.json"
+        },
+        {
+            "name": "Haven",
+            "location": "https://raw.githubusercontent.com/h4ven88/hestia-dashboard/main/repository.json"
+        },
+        {
+            "name": "brossow",
+            "location": "https://raw.githubusercontent.com/brossow/hubitat-drivers/main/repository.json"
+        },
+        {
+            "name": "uDevel",
+            "location": "https://raw.githubusercontent.com/uDevel/hubitat-soma-shades-3/main/repository.json"
+        }
+    ],
+    "hpm": {
+        "location": "https://raw.githubusercontent.com/HubitatCommunity/hubitatpackagemanager/main/packageManifest.json"
+    }
 }


### PR DESCRIPTION
Updating my repository location from the old `hubitat-econet` repo (now archived) to my new consolidated `hubitat-drivers` monorepo.

The new `repository.json` at this URL includes all four of my drivers:
- Aeotec Heavy Duty Smart Switch
- BirdWeather PUC
- Rheem EcoNet (thermostat + water heater)
- Xiaomi/Aqara Temperature & Humidity Sensor