### PR TITLE
Add level99 / Levoit-VeSync drivers

### DIFF
--- a/repositories.json
+++ b/repositories.json
@@ -791,6 +791,10 @@
 		{
 			"name": "uDevel",
 			"location": "https://raw.githubusercontent.com/uDevel/hubitat-soma-shades-3/main/repository.json"
+		},
+		{
+			"name": "Dan Cox (level99)",
+			"location": "https://raw.githubusercontent.com/level99/Hubitat-VeSync/main/repository.json"
 		}
 	],
 	"hpm": {


### PR DESCRIPTION
Adds a new author entry pointing at level99/Hubitat-VeSync's repository.json.

Maintains Hubitat drivers for Levoit air purifiers (Core 200S/300S/400S/600S, Vital 200S), humidifiers (Superior 6000S), and a Generic Levoit Diagnostic Driver fall-through for unsupported Levoit models.

Repository: https://github.com/level99/Hubitat-VeSync
Manifest: https://raw.githubusercontent.com/level99/Hubitat-VeSync/main/levoitManifest.json