### PR TITLE
Add @madskristensen — hubitat-drivers

### DIFF
--- a/repositories.json
+++ b/repositories.json
@@ -568,6 +568,10 @@
 			"name": "Lyle Pakula (@lpakula)",
 			"location": "https://raw.githubusercontent.com/wir3z/hubitat/main/repository.json"
 		},
+	{
+		"name": "Mads Kristensen",
+		"location": "https://raw.githubusercontent.com/madskristensen/hubitat-drivers/main/repository.json"
+	},
 		{
 			"name":"Rene Boer",
 			"location": "https://raw.githubusercontent.com/reneboer/Hubitat/main/hpm/respository.json"


### PR DESCRIPTION
Adding my repository to the HPM community list.

- **Author:** Mads Kristensen
- **Repository:** https://github.com/madskristensen/hubitat-drivers
- **Manifest:** https://raw.githubusercontent.com/madskristensen/hubitat-drivers/main/repository.json
- **Packages:** Gemstone Lights v0.4.0 — cloud REST driver for Gemstone permanent outdoor lighting

---

*Submitted via HPM community list PR flow per https://hubitatpackagemanager.hubitatcommunity.com/devs1.html*
