### PR TITLE
Update location for Ultrasmart.pl repository

### DIFF
--- a/repositories.json
+++ b/repositories.json
@@ -802,7 +802,7 @@
 		},
 		{
 			"name": "Ultrasmart.pl",
-			"location": "https://raw.githubusercontent.com/MarioHudds/Hubitat-Hub-Monitor/refs/heads/main/repository.json"
+			"location": "https://raw.githubusercontent.com/MarioHudds/Hubitat-Hub-Monitor/refs/heads/main/packageManifest.json"
 		},
 		{
 			"name": "Jessica Jones (@jess)",


### PR DESCRIPTION
Changed to packageManifest.json as the repository.json did not show in HPM.