### PR TITLE
Fix location URL for Ultrasmart.pl repository

### DIFF
--- a/repositories.json
+++ b/repositories.json
@@ -810,7 +810,7 @@
 		},
 		{
 			"name": "Ultrasmart.pl",
-			"location": "https://raw.githubusercontent.com/MarioHudds/Hubitat-Hub-Monitor/refs/heads/main/packageManifest.json"
+			"location": "https://raw.githubusercontent.com/MarioHudds/Hubitat-Hub-Monitor/refs/heads/main/repository.json"
 		},
 		{
 			"name": "Roger Noia (rnoia)",


### PR DESCRIPTION
Fixed repository.jeson and packageManifest.json. Added repository.json as an intermediate. 