### PR TITLE
Add zshenker repository (HomeSeer PS100 mmWave presence sensor)

### DIFF
--- a/repositories.json
+++ b/repositories.json
@@ -823,6 +823,10 @@
 		{
 			"name": "waterboysh",
 			"location": "https://raw.githubusercontent.com/waterboysh/hubitat/main/repository.json"
+		},
+		{
+			"name": "zshenker",
+			"location": "https://raw.githubusercontent.com/zshenker/hubitat-homeseer-ps100/main/repository.json"
 		}
 	],
 	"hpm": {


### PR DESCRIPTION
Adds my package repository to the community list.

- **Author:** zshenker
- **Repository:** https://github.com/zshenker/hubitat-homeseer-ps100
- **repository.json:** https://raw.githubusercontent.com/zshenker/hubitat-homeseer-ps100/main/repository.json

The repository currently contains one package: a Hubitat Z-Wave Plus driver for the **HomeSeer PS100** 24 GHz mmWave presence sensor (supports both hardware revisions, `000C:0204:0002` and `000C:0204:0003`).

I verified that the `repository.json` and the linked `packageManifest.json` are valid JSON and return HTTP 200.