### PR TITLE
Add jlslate repository

### DIFF
--- a/repositories.json
+++ b/repositories.json
@@ -823,6 +823,10 @@
 		{
 			"name": "zshenker",
 			"location": "https://raw.githubusercontent.com/zshenker/hubitat-homeseer-ps100/main/repository.json"
+		},
+		{
+			"name": "jlslate",
+			"location": "https://raw.githubusercontent.com/jlslate/SenseCAP-Indicator/main/repository.json"
 		}
 	],
 	"hpm": {


### PR DESCRIPTION
Adds my repository to the community list.

`repository.json` (https://raw.githubusercontent.com/jlslate/SenseCAP-Indicator/main/repository.json) currently lists two packages:

- **SenseCAP Indicator** — App + driver pair for the SenseCAP Indicator D1 touchscreen, driving up to 12 dashboard pages (motion, contact, water, smoke, lock, garage, light, thermostat, weather, alarm clock) over MQTT via openHASP firmware.
- **Composite Device** — Parent/child app + virtual driver that pools multiple real devices of a single chosen type (water, lock, door, window, smoke, motion, garage door, temperature, humidity, illuminance) into one virtual device.

Both package manifests are live and validated as JSON:
- https://raw.githubusercontent.com/jlslate/SenseCAP-Indicator/main/packageManifest.json
- https://raw.githubusercontent.com/jlslate/Composite-Device/main/packageManifest.json