### PR TITLE
Add mclass repository

### DIFF
--- a/repositories.json
+++ b/repositories.json
@@ -827,6 +827,10 @@
 		{
 			"name": "jlslate",
 			"location": "https://raw.githubusercontent.com/jlslate/SenseCAP-Indicator/main/repository.json"
+		},
+		{
+			"name": "mclass",
+			"location": "https://raw.githubusercontent.com/Mclass294/hubitat-sigenergy/main/repository.json"
 		}
 	],
 	"hpm": {


### PR DESCRIPTION
Adds the mclass Hubitat package repository containing the Sigenergy Plant Driver.

Repository:
https://raw.githubusercontent.com/Mclass294/hubitat-sigenergy/main/repository.json