### PR TITLE
Add mclass repository

### DIFF
--- a/repositories.json
+++ b/repositories.json
@@ -831,6 +831,10 @@
 		{
 			"name": "PositionGuard",
 			"location": "https://raw.githubusercontent.com/positionguard/positionguard-hubitat/main/repository.json"
+		},
+		{
+			"name": "mclass",
+			"location": "https://raw.githubusercontent.com/Mclass294/hubitat-sigenergy/main/repository.json"
 		}
 	],
 	"hpm": {


### PR DESCRIPTION
Adds the mclass Hubitat package repository containing the Sigenergy Plant Driver.

Repository:
https://raw.githubusercontent.com/Mclass294/hubitat-sigenergy/main/repository.json

GitHub:
https://github.com/Mclass294/hubitat-sigenergy

Community thread:
https://community.hubitat.com/t/release-sigenergy-plant-driver-local-modbus-tcp/164791