### PR TITLE
Add Daikin BRP084 Local Controller repository

### DIFF
--- a/repositories.json
+++ b/repositories.json
@@ -835,9 +835,9 @@
 		{
 			"name": "mclass",
 			"location": "https://raw.githubusercontent.com/Mclass294/hubitat-sigenergy/main/repository.json"
-		}
+		},
 		{
-            "name": "mclass",
+            "name": "mclass (Daikin)",
             "location": "https://raw.githubusercontent.com/Mclass294/Hubitat-Daikin-BRP084/main/repository.json"
         }
 	],

--- a/repositories.json
+++ b/repositories.json
@@ -836,6 +836,10 @@
 			"name": "mclass",
 			"location": "https://raw.githubusercontent.com/Mclass294/hubitat-sigenergy/main/repository.json"
 		}
+		{
+            "name": "mclass",
+            "location": "https://raw.githubusercontent.com/Mclass294/Hubitat-Daikin-BRP084/main/repository.json"
+        }
 	],
 	"hpm": {
 		"location": "https://raw.githubusercontent.com/HubitatCommunity/hubitatpackagemanager/main/packageManifest.json"


### PR DESCRIPTION
This PR adds the repository for the Daikin BRP084 Local Controller.

Repository:
https://github.com/Mclass294/Hubitat-Daikin-BRP084

Features:

- Native local DSIoT communications
- No cloud required
- No Home Assistant required
- Hubitat Package Manager compatible

Current release:
v1.0.0