### PR TITLE
Add UltronOfSpace repository (Zen32 LED Coordinator)

### DIFF
--- a/repositories.json
+++ b/repositories.json
@@ -839,6 +839,10 @@
 		{
 			"name": "Kevin Kahl (@kahlkevin)",
 			"location": "https://raw.githubusercontent.com/kahlkevin/hpm-repo/main/repository.json"
+		},
+		{
+			"name": "UltronOfSpace",
+			"location": "https://raw.githubusercontent.com/UltronOfSpace/Hubitat/main/repository.json"
 		}
 	],
 	"hpm": {


### PR DESCRIPTION
Adds my developer repository to the registry.

**Package:** Zen32 LED Coordinator — parent/child app pair that syncs Zooz ZEN32 scene controller button LEDs with the state of other devices.

- Repository file: https://raw.githubusercontent.com/UltronOfSpace/Hubitat/main/repository.json
- Package manifest: https://raw.githubusercontent.com/UltronOfSpace/Hubitat/main/Zen32/packageManifest.json
- Release thread: https://community.hubitat.com/t/release-zen32-led-coordinator-keeps-your-zen32-button-leds-honest/165070

Manifest installs cleanly via HPM "From a URL" today; JSON validated. Thanks for maintainin' the list, boys.