### PR TITLE
Add evdev Modern Dashboard repository

### DIFF
--- a/repositories.json
+++ b/repositories.json
@@ -843,6 +843,10 @@
 		{
 			"name": "UltronOfSpace",
 			"location": "https://raw.githubusercontent.com/UltronOfSpace/Hubitat/main/repository.json"
+		},
+		{
+			"name": "evdev",
+			"location": "https://raw.githubusercontent.com/evdev/hubitat-modern-dashboard/master/hubitat/repository.json"
 		}
 	],
 	"hpm": {


### PR DESCRIPTION
## Summary

Adds the **evdev** HPM repository for [Modern Dashboard (mDash)](https://github.com/evdev/hubitat-modern-dashboard).

- **Repository JSON:** `https://raw.githubusercontent.com/evdev/hubitat-modern-dashboard/master/hubitat/repository.json`
- **Category:** Convenience
- **Minimum HE version:** 2.3.0
- **OAuth:** yes (HPM deploys app + 12 File Manager assets automatically)
- **Community thread:** https://community.hubitat.com/t/release-modern-dashboard-mdash-minimal-setup-pwa-with-built-in-scheduler-runs-entirely-on-your-hub/165028

Control-first Hubitat dashboard: select devices and go — rooms/layout automatic, PWA installable from cloud URL, built-in remote scheduler, runs entirely on the hub (no Maker API or third-party cloud).

## Test plan

- [ ] Verify `repositories.json` parses as valid JSON
- [ ] Confirm repository URL returns a valid HPM repository manifest
- [ ] Confirm package manifest URL in that file is reachable on `master`


Made with [Cursor](https://cursor.com)