### PR TITLE
Add new repository entries for hubitrep and classic-dave

### DIFF
--- a/repositories.json
+++ b/repositories.json
@@ -855,6 +855,10 @@
 		{
 			"name": "hubitrep",
 			"location": "https://raw.githubusercontent.com/hubitrep/hubitat/refs/heads/main/repository.json"
+		},
+		{
+			"name": "classic-dave",
+			"location": "https://raw.githubusercontent.com/classic-dave/hubitat-dreo/main/repository.json"
 		}
 	],
 	"hpm": {


### PR DESCRIPTION
Adds my repository, currently one package.

**Dreo Integration** provides cloud control of Dreo fans, air circulators, air purifiers, ceiling fans and humidifiers. Ported from Dreo's official Home Assistant integration (MIT licensed).

- Repository JSON: https://raw.githubusercontent.com/classic-dave/hubitat-dreo/main/repository.json
- Source: https://github.com/classic-dave/hubitat-dreo
- Community thread: https://community.hubitat.com/t/beta-dreo-fan-integration-cloud/165215
- Category: Integrations
- Tags: Climate Control, Appliances, Cloud